### PR TITLE
Secret DB connection string

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -31,4 +31,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore QuizAPI.sln
     - name: Deploy to Lambda
-      run: dotnet lambda deploy-serverless --aws-access-key-id ${{ env.AWS_ACCESS_KEY_ID }} --aws-secret-key ${{ env.AWS_SECRET_ACCESS_KEY}} -cfg deployment-defaults.json
+      run: dotnet lambda deploy-serverless -sn triviapi -sb triviapi-code-repo --region eu-west-1 -t serverless.template

--- a/QuizAPI/Model/TriviapiDBContext.cs
+++ b/QuizAPI/Model/TriviapiDBContext.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+using System.Text.Json;
+using QuizAPI.Utils;
 
 namespace QuizAPI.Model
 {
@@ -9,11 +11,13 @@ namespace QuizAPI.Model
     {
         public TriviapiDBContext()
         {
+
         }
 
         public TriviapiDBContext(DbContextOptions<TriviapiDBContext> options)
             : base(options)
         {
+            Console.WriteLine(JsonSerializer.Serialize(options));
         }
 
         public virtual DbSet<Category> Categories { get; set; } = null!;
@@ -25,13 +29,11 @@ namespace QuizAPI.Model
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
+    
             if (!optionsBuilder.IsConfigured)
             {
-                IConfiguration _configuration = new ConfigurationBuilder()
-                    .SetBasePath(Directory.GetCurrentDirectory())
-                    .AddJsonFile("appsettings.json")
-                    .Build();
-                string myDbConnection = _configuration.GetConnectionString("QuizDB");
+                var appSettings = AppSettings.instance();
+                string myDbConnection = appSettings.connectionString;
                 optionsBuilder.UseSqlServer(myDbConnection);
             }
         }

--- a/QuizAPI/Program.cs
+++ b/QuizAPI/Program.cs
@@ -1,8 +1,12 @@
 using Microsoft.EntityFrameworkCore;
 using QuizAPI.Model;
 using System.Text.Json.Serialization;
+using QuizAPI.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
+
+var env = builder.Environment.EnvironmentName;
+var appName = builder.Environment.ApplicationName; 
 
 // Add services to the container.
 
@@ -10,7 +14,19 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+builder.Configuration.AddSecretsManager(region: Amazon.RegionEndpoint.EUWest1,
+	configurator: options => 
+	{
+		options.KeyGenerator = (_, s) => s
+            .Replace("__", ":"); 
+	});
+
 var connectionString = builder.Configuration.GetConnectionString("QuizDB");
+
+var appSettings = AppSettings.instance();
+appSettings.connectionString = connectionString; 
+
 builder.Services.AddDbContext<TriviapiDBContext>(x => x.UseSqlServer(connectionString));
 
 builder.Services.AddAWSLambdaHosting(LambdaEventSource.RestApi);

--- a/QuizAPI/QuizAPI.csproj
+++ b/QuizAPI/QuizAPI.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.3.0" />
     <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.2.52" />
+    <PackageReference Include="Kralizek.Extensions.Configuration.AWSSecretsManager" Version="1.6.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">

--- a/QuizAPI/Utils/AppSettings.cs
+++ b/QuizAPI/Utils/AppSettings.cs
@@ -1,0 +1,24 @@
+namespace QuizAPI.Utils
+{
+    public class AppSettings 
+    {
+        AppSettings(){
+            this.connectionString = "";
+        }
+        public string connectionString {get; set;}
+
+        private static AppSettings? Instance {get; set;}
+
+        public static AppSettings instance()
+        {
+            if(Instance == null)
+            {
+                Instance = new AppSettings();
+            }
+
+            return Instance;
+        }
+
+    }
+
+}

--- a/QuizAPI/appsettings.json
+++ b/QuizAPI/appsettings.json
@@ -5,8 +5,5 @@
         "Microsoft.AspNetCore": "Warning"
       }
     },
-    "AllowedHosts": "*",
-    "ConnectionStrings": {
-      "QuizDB": "server=triviapi.cywd7qphawxe.af-south-1.rds.amazonaws.com;uid=admin;pwd=7N4mTKQabpfUY0808IfD;database=TriviapiDB"
-    }
+    "AllowedHosts": "*"
 }

--- a/QuizAPI/deployment-defaults.json
+++ b/QuizAPI/deployment-defaults.json
@@ -1,7 +1,0 @@
-{
-    "stack-name": "triviapi",
-    "s3-bucket": "triviapi-code-repo",
-    "template": "serverless.template",
-    "region": "eu-west-1",
-    "configuration": "Release"
-}


### PR DESCRIPTION
This pull request removes the connection string from appsettings.json

It does this by using AWS secrets manager - you're gonna need to configure the aws user credentials in your own envirnment. I have put the commands to set the env variables in TOPSECRET.txt on teams. Once you do that you can test with ```dotnet run``` to test it locally. 

Holding thumbs it works with the github actions pipeline once merged into main!
